### PR TITLE
change variable name from 'auto_plugins' to 'plugins'

### DIFF
--- a/miniperf.sh
+++ b/miniperf.sh
@@ -158,7 +158,7 @@ then
    do
       service_name="service-$i"
       curl $KONG_ADMIN/services -d "name=$service_name" -d "url=$KONG_DEMO_UPSTREAM_URL" &> $curl_output
-      for plugin in "${auto_plugins[@]}"
+      for plugin in "${plugins[@]}"
       do
          add_plugin "$service_name"
       done


### PR DESCRIPTION
Currently `miniperf.sh` script doesn't work as expected. Regardless of run mode I choose, results are roughly the same all the time.
I found that during tests no plugins are added because scripts uses undefined `auto_plugins` variable. Changing it to `plugins` (which is unused otherwise) solves this issue.


BTW this script is awesome, thank you guys for it.